### PR TITLE
feat: use enum discriminant name for type name

### DIFF
--- a/poem-openapi-derive/src/union.rs
+++ b/poem-openapi-derive/src/union.rs
@@ -90,8 +90,9 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
         }
 
         let object_ty = &variant.fields.fields[0];
+        let format_string = format!("{{}}_{}", item_ident);
         let schema_name = quote! {
-            ::std::format!("{}_{}", <Self as #crate_name::types::Type>::name(), <#object_ty as #crate_name::types::Type>::name())
+            ::std::format!(#format_string, <Self as #crate_name::types::Type>::name())
         };
         let mapping_name = match &variant.mapping {
             Some(mapping) => mapping.clone(),

--- a/poem-openapi/tests/union.rs
+++ b/poem-openapi/tests/union.rs
@@ -22,7 +22,7 @@ fn get_meta_by_name<T: Type>(name: &str) -> MetaSchema {
 #[test]
 fn with_discriminator() {
     #[derive(Object, Debug, PartialEq)]
-    struct A {
+    struct AContents {
         v1: i32,
         v2: String,
     }
@@ -35,7 +35,7 @@ fn with_discriminator() {
     #[derive(Union, Debug, PartialEq)]
     #[oai(discriminator_name = "type")]
     enum MyObj {
-        A(A),
+        A(AContents),
         B(B),
     }
 
@@ -79,7 +79,7 @@ fn with_discriminator() {
                     )],
                     ..MetaSchema::new("object")
                 })),
-                MetaSchemaRef::Reference("A".to_string()),
+                MetaSchemaRef::Reference("AContents".to_string()),
             ],
             ..MetaSchema::ANY
         }
@@ -116,14 +116,14 @@ fn with_discriminator() {
             "v2": "hello",
         })))
         .unwrap(),
-        MyObj::A(A {
+        MyObj::A(AContents {
             v1: 100,
             v2: "hello".to_string()
         })
     );
 
     assert_eq!(
-        MyObj::A(A {
+        MyObj::A(AContents {
             v1: 100,
             v2: "hello".to_string()
         })
@@ -559,17 +559,17 @@ fn rename_all() {
                 mapping: vec![
                     (
                         "putInt".to_string(),
-                        "#/components/schemas/MyObj_A".to_string()
+                        "#/components/schemas/MyObj_PutInt".to_string()
                     ),
                     (
                         "putString".to_string(),
-                        "#/components/schemas/MyObj_B".to_string()
+                        "#/components/schemas/MyObj_PutString".to_string()
                     ),
                 ]
             }),
             any_of: vec![
-                MetaSchemaRef::Reference("MyObj_A".to_string()),
-                MetaSchemaRef::Reference("MyObj_B".to_string()),
+                MetaSchemaRef::Reference("MyObj_PutInt".to_string()),
+                MetaSchemaRef::Reference("MyObj_PutString".to_string()),
             ],
             ..MetaSchema::ANY
         }


### PR DESCRIPTION
When generating the different union discriminant, use the name of the discriminant instead of the name of the type inside the discriminant. This allows reuse of the type for multiple enumeration discriminants.

BREAKING CHANGE: the type names in the generated OpenAPI spec are changed, but the contents of the types are the same.

Fixes #1038